### PR TITLE
MentalStateInterface pom file incremented version number to 1.3.7-SNA…

### DIFF
--- a/mentalStateInterface/pom.xml
+++ b/mentalStateInterface/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.goalhub.mentalstate</groupId>
 	<artifactId>mentalstateinterface</artifactId>
-	<version>1.3.6</version>
+	<version>1.3.7-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Mental State Interface definition</name>


### PR DESCRIPTION
Version number updated so maven dependency for this fork can be created in runtime repo